### PR TITLE
Update presets from community

### DIFF
--- a/tag_game_presets.json
+++ b/tag_game_presets.json
@@ -669,7 +669,7 @@
                     "right2"
                 ]
             },
-            "min_players": 10,
+            "min_players": 8,
             "max_players": 20,
             "transitions": {
                 "White_Palace_15": [
@@ -851,6 +851,265 @@
             }
         },
         {
+            "name": "queens-gardens-stag",
+            "warp_transitions": {
+                "Fungus3_13": [
+                    "bot1"
+                ],
+                "Fungus3_49": [
+                    "bot1"
+                ],
+                "Fungus1_23": [
+                    "left1"
+                ]
+            },
+            "min_players": 8,
+            "max_players": 15,
+            "transitions": {
+                "Fungus3_13": [
+                    "right1",
+                    "bot1"
+                ]
+            },
+            "loadouts": {
+                "normal": {
+                    "charms": [
+                        "WaywardCompass", "Kingsoul", "Dashmaster", "SporeShroom"
+                    ],
+                    "skills": [
+                        "CycloneSlash", "DashSlash", "GreatSlash", "MantisClaw", "CrystalHeart", "MonarchWings",
+                        "IsmasTear", "ShadeCloak", "MothwingCloak", "VengefulSpirit"
+                    ]
+                },
+                "infected": {
+                    "charms": [
+                        "NailmastersGlory", "Dashmaster", "Sprintmaster", "SharpShadow"
+                    ],
+                    "skills": [
+                        "CycloneSlash", "DashSlash", "GreatSlash", "MantisClaw", "CrystalHeart", "MonarchWings",
+                        "IsmasTear", "ShadeCloak", "MothwingCloak"
+                    ]
+                }
+            }
+        },
+        {
+            "name": "queens-gardens-petra-small",
+            "warp_transitions": {
+                "Fungus3_08": [
+                    "right1"
+                ]
+            },
+            "min_players": 3,
+            "max_players": 6,
+            "transitions": {
+                "Fungus3_08": [
+                    "right1",
+                    "left1",
+                    "top1"
+                ]
+            },
+            "loadouts": {
+                "normal": {
+                    "charms": [
+                        "WaywardCompass", "Kingsoul", "Dashmaster", "Flukenest", "SharpShadow"
+                    ],
+                    "skills": [
+                        "CycloneSlash", "DashSlash", "GreatSlash", "MantisClaw", "CrystalHeart", "MonarchWings",
+                        "IsmasTear", "ShadeCloak", "MothwingCloak", "VengefulSpirit"
+                    ]
+                },
+                "infected": {
+                    "charms": [
+                        "NailmastersGlory", "Dashmaster", "Sprintmaster"
+                    ],
+                    "skills": [
+                        "CycloneSlash", "DashSlash", "GreatSlash", "MantisClaw", "CrystalHeart", "MonarchWings",
+                        "IsmasTear", "ShadeCloak", "MothwingCloak"
+                    ]
+                }
+            }
+        },
+        {
+            "name": "queens-gardens-petra-medium",
+            "warp_transitions": {
+                "Fungus3_08": [
+                    "left1"
+                ],
+                "Fungus3_10": [
+                    "top1"
+                ],
+                "Fungus3_39": [
+                    "left1"
+                ]
+            },
+            },
+            "min_players": 6,
+            "max_players": 20,
+            "transitions": {
+                "Fungus3_10": [
+                    "top1"
+                ],
+                "Fungus3_08": [
+                    "left1"
+                ],
+                "Fungus3_39": [
+                    "right1"
+                ],
+                "Fungus3_11": [
+                    "right1",
+                    "left1"
+                ]
+            },
+            "loadouts": {
+                "normal": {
+                    "charms": [
+                        "WaywardCompass", "Kingsoul", "Dashmaster", "Flukenest", "BaldurShell"
+                    ],
+                    "skills": [
+                        "CycloneSlash", "DashSlash", "GreatSlash", "MantisClaw", "CrystalHeart", "MonarchWings",
+                        "IsmasTear", "ShadeCloak", "MothwingCloak", "VengefulSpirit"
+                    ]
+                },
+                "infected": {
+                    "charms": [
+                        "NailmastersGlory", "Dashmaster", "Sprintmaster"
+                    ],
+                    "skills": [
+                        "CycloneSlash", "DashSlash", "GreatSlash", "MantisClaw", "CrystalHeart", "MonarchWings",
+                        "IsmasTear", "ShadeCloak", "MothwingCloak"
+                    ]
+                }
+            }
+        },
+        {
+            "name": "queens-gardens-petra-large",
+            "warp_transitions": {
+                "Fungus3_08": [
+                    "left1"
+                ],
+                "Fungus3_05": [
+                    "left1"
+                ],
+                "Fungus3_24": [
+                    "left1"
+                ],
+                "Fungus3_39": [
+                    "left1"
+                ]
+            },
+            "min_players": 10,
+            "max_players": 30,
+            "transitions": {
+                "Fungus3_08": [
+                    "left1"
+                ],
+                "Fungus3_39": [
+                    "right1"
+                ],
+                "Fungus3_04": [
+                    "right1",
+                    "left1"
+                ],
+                "Fungus3_13": [
+                    "left2",
+                    "left1"
+                ]
+            },
+            "loadouts": {
+                "normal": {
+                    "charms": [
+                        "WaywardCompass", "Kingsoul", "Dashmaster", "Flukenest", "BaldurShell"
+                    ],
+                    "skills": [
+                        "CycloneSlash", "DashSlash", "GreatSlash", "MantisClaw", "CrystalHeart", "MonarchWings",
+                        "IsmasTear", "ShadeCloak", "MothwingCloak", "VengefulSpirit"
+                    ]
+                },
+                "infected": {
+                    "charms": [
+                        "NailmastersGlory", "Dashmaster", "Sprintmaster", "SharpShadow"
+                    ],
+                    "skills": [
+                        "CycloneSlash", "DashSlash", "GreatSlash", "MantisClaw", "CrystalHeart", "MonarchWings",
+                        "IsmasTear", "ShadeCloak", "MothwingCloak"
+                    ]
+                }
+            }
+        },
+        {
+            "name": "queens-gardens-love",
+            "warp_transitions": {
+                "Fungus3_39": [
+                    "left1",
+                    "right1"
+                ]
+            },
+            "min_players": 3,
+            "max_players": 7,
+            "transitions": {
+                "Fungus3_39": [
+                    "right1",
+                    "left1"
+                ]
+            },
+            "loadouts": {
+                "normal": {
+                    "charms": [
+                        "WaywardCompass", "Kingsoul", "Dashmaster", "Flukenest"
+                    ],
+                    "skills": [
+                        "CycloneSlash", "DashSlash", "GreatSlash", "MantisClaw", "CrystalHeart", "MonarchWings",
+                        "IsmasTear", "ShadeCloak", "MothwingCloak", "VengefulSpirit"
+                    ]
+                },
+                "infected": {
+                    "charms": [
+                        "NailmastersGlory", "Dashmaster", "Sprintmaster", "SharpShadow"
+                    ],
+                    "skills": [
+                        "CycloneSlash", "DashSlash", "GreatSlash", "MantisClaw", "CrystalHeart", "MonarchWings",
+                        "IsmasTear", "ShadeCloak", "MothwingCloak"
+                    ]
+                }
+            }
+        },
+        {
+            "name": "queens-gardens-marmu",
+            "warp_transitions": {
+                "Fungus3_40": [
+                    "top1"
+                ]
+            },
+            "min_players": 3,
+            "max_players": 5,
+            "transitions": {
+                "Fungus3_40": [
+                    "top1",
+                    "right1"
+                ]
+            },
+            "loadouts": {
+                "normal": {
+                    "charms": [
+                        "WaywardCompass", "Kingsoul", "Dashmaster", "Flukenest", "BaldurShell"
+                    ],
+                    "skills": [
+                        "CycloneSlash", "DashSlash", "GreatSlash", "MantisClaw", "CrystalHeart", "MonarchWings",
+                        "IsmasTear", "ShadeCloak", "MothwingCloak", "VengefulSpirit"
+                    ]
+                },
+                "infected": {
+                    "charms": [
+                        "NailmastersGlory", "Dashmaster", "Sprintmaster", "SharpShadow"
+                    ],
+                    "skills": [
+                        "CycloneSlash", "DashSlash", "GreatSlash", "MantisClaw", "CrystalHeart", "MonarchWings",
+                        "IsmasTear", "ShadeCloak", "MothwingCloak"
+                    ]
+                }
+            }
+        },
+        {
             "name": "queens-gardens-medium",
             "warp_transitions": {
                 "Fungus1_24": [
@@ -871,7 +1130,7 @@
                         "WaywardCompass", "Kingsoul", "Flukenest", "Sprintmaster"
                     ],
                     "skills": [
-                        "CycloneSlash", "DashSlash", "MothwingCloak", "MantisClaw", "MonarchWings", "IsmasTear", 
+                        "CycloneSlash", "DashSlash", "GreatSlash", "MothwingCloak", "MantisClaw", "MonarchWings", "IsmasTear", 
                         "VengefulSpirit"
                     ]
                 },
@@ -1876,6 +2135,61 @@
                     "skills": [
                         "MothwingCloak", "MantisClaw", "CrystalHeart", "MonarchWings", "IsmasTear", 
                         "ShadeCloak", "CycloneSlash", "DashSlash", "DesolateDive"
+                    ]
+                }
+            }
+        },
+        {
+            "name": "enter-hallownest",
+            "warp_transitions": {
+                "Cliffs_02": [
+                    "door1"
+                ],
+                "Town": [
+                    "door_jiji"
+                ],
+                "Tutorial_01": [
+                    "right1"
+                ],
+                "Crossroads_01": [
+                    "left1"
+                ]
+            },
+            "min_players": 8,
+            "max_players": 25,
+            "transitions": {
+                "Cliffs_02": [
+                    "left1",
+                    "left2"
+                ],
+                "Town": [
+                    "right1",
+                    "door_mapper",
+                    "door_sly",
+                    "door_bretta"
+                ],
+                "Crossroads_01": [
+                    "right1",
+                    "left1"
+                ]
+            },
+            "loadouts": {
+                "normal": {
+                    "charms": [
+                        "WaywardCompass", "Kingsoul", "BaldurShell", "StalwartShell", "Sprintmaster"
+                    ],
+                    "skills": [
+                        "CycloneSlash", "DashSlash", "GreatSlash", "MothwingCloak", "MantisClaw", "MonarchWings", "IsmasTear", 
+                        "VengefulSpirit", "HowlingWraiths", "DesolateDive"
+                    ]
+                },
+                "infected": {
+                    "charms": [
+                        "NailmastersGlory", "Dashmaster", "SharpShadow", "Grubsong"
+                    ],
+                    "skills": [
+                        "CycloneSlash", "DashSlash", "GreatSlash", "MantisClaw", "CrystalHeart", "MonarchWings",
+                        "IsmasTear", "ShadeCloak"
                     ]
                 }
             }

--- a/tag_game_presets.json
+++ b/tag_game_presets.json
@@ -669,7 +669,7 @@
                     "right2"
                 ]
             },
-            "min_players": 8,
+            "min_players": 10,
             "max_players": 20,
             "transitions": {
                 "White_Palace_15": [
@@ -941,7 +941,6 @@
                 "Fungus3_39": [
                     "left1"
                 ]
-            },
             },
             "min_players": 6,
             "max_players": 20,
@@ -2155,7 +2154,7 @@
                     "left1"
                 ]
             },
-            "min_players": 8,
+            "min_players": 10,
             "max_players": 25,
             "transitions": {
                 "Cliffs_02": [


### PR DESCRIPTION
Another bunch of presets: This time primarily located in Queen Gardens. Added Jordy's suggestion of Howling Cliffs/Gorb preset and reverted the minimum player count of his white palace preset back to 8 from 10 as per his request. Though, I still feel like the preset is a bit big for 8 players, so it is up to you if you want to keep this change.

Everything should be good, even though the Github is a bit different from how the indents, etc are set out in notepad. Tested the presets with the notepad version but not the Github version though, and they were working there.